### PR TITLE
Change PRIMARY INDEX column name

### DIFF
--- a/docs/sql-reference/commands/ddl-commands.md
+++ b/docs/sql-reference/commands/ddl-commands.md
@@ -682,7 +682,7 @@ CREATE DIMENSION TABLE my_cstmr_dim (
   phone1 TEXT,
   phone2 TEXT,
   status TEXT)
-PRIMARY INDEX my_cstmr_id;
+PRIMARY INDEX cstmr_id;
 ```
 
 Queries often run that join different fact tables with this dimension table. Those queries `SELECT` the `name` and `email` of customers in the returned results. Another set of queries often select `city` and `status` in returned results with a join. The following join index helps to accelerate these queries.


### PR DESCRIPTION
We will get an error "Code: 10001, e.displayText() = DB::Exception: Invalid operation error: Primary index 'my_cstmr_id' doesn't appear in column list (version 21.6.5.1)"
 'my_cstmr_id'  it is the name of the table but not of the column