### PR TITLE
Update release-notes.md

### DIFF
--- a/docs/general-reference/release-notes.md
+++ b/docs/general-reference/release-notes.md
@@ -92,5 +92,3 @@ Firebolt might roll out releases in phases. New features and changes may not yet
 ### Resolved issues
 
 * <!--- FIR-11369 --> An error message is now displayed when too many partitions are added using a single `INSERT` statement.
-
-* <!--- FIR-11193--> Fixed an issue where casting to timestamp concatenated strings, representing the date and time parts, returned an incorrect timestamp value.


### PR DESCRIPTION
Remove * <!--- FIR-11193--> Fixed an issue where casting to timestamp concatenated strings, representing the date and time parts, returned an incorrect timestamp value.