### PR TITLE
Fix return type of JSON_EXTRACT_ARRAY_RAW

### DIFF
--- a/docs/sql-reference/functions-reference/json-extract-array-raw.md
+++ b/docs/sql-reference/functions-reference/json-extract-array-raw.md
@@ -7,7 +7,7 @@ parent: SQL functions
 
 # JSON_EXTRACT_ARRAY_RAW
 
-Returns a string representation of a JSON array pointed by the supplied JSON pointer. The returned string represents a Firebolt array with elements that are string representations of the scalars or objects contained in the JSON array under the specified key, if the key exists. If the key does not exist, the function returns `NULL`.
+Returns a string representation of a JSON array pointed by the supplied JSON pointer. The returned string represents a Firebolt array with elements that are string representations of the scalars or objects contained in the JSON array under the specified key, if the key exists. If the key does not exist, the function returns an empty array.
 
 This function is useful when working with heterogeneously typed arrays and arrays containing JSON objects in which case each object will be further processed by functions such as [TRANSFORM](/transform.md).
 


### PR DESCRIPTION
We don't support nullable arrays, so this certainly can't return `NULL`. It returns `[]`, the empty array.