### PR TITLE
Partition keys and floating point data type columns

### DIFF
--- a/docs/working-with-partitions.md
+++ b/docs/working-with-partitions.md
@@ -58,6 +58,8 @@ Partition key arguments must not evaluate to `NULL` and can be any of the follow
   ```sql
   PARTITION BY EXTRACT(MONTH FROM date_column), product_type;
   ```
+{: .caution}
+Floating point data type columns are not supported as partition keys.
 
 ## Dropping partitions
 


### PR DESCRIPTION
Added {: .caution} Floating point data type columns are not supported as partition keys.