### PR TITLE
Function definitions to use Parameters over Arguments.

### DIFF
--- a/function-template.md
+++ b/function-template.md
@@ -18,7 +18,7 @@ Function description
 
 <Syntax>
 
-## Arguments
+## Parameters
 {: .no_toc}
 
 | Parameter | Description                         | Supported input types |


### PR DESCRIPTION
In documentation of function definition - use term "Parameter". The term "Argument" is for concrete instantiation during function call, and is used in error messages.