### PR TITLE
Update current-timestamp.md

### DIFF
--- a/docs/sql-reference/functions-reference/current-timestamp.md
+++ b/docs/sql-reference/functions-reference/current-timestamp.md
@@ -13,7 +13,7 @@ Returns the current year, month, day and time as a `TIMESTAMP` value, formatted 
 {: .no_toc}
 
 ```sql
-CURRENT_TIMESTAMP()
+CURRENT_TIMESTAMP
 ```
 
 ## Example
@@ -21,7 +21,7 @@ CURRENT_TIMESTAMP()
 
 ```
 SELECT
-    CURRENT_TIMESTAMP();
+    CURRENT_TIMESTAMP;
 ```
 
 **Returns**: `2022-10-12 19:39:22`


### PR DESCRIPTION
It's not allowed to invoke `CURRENT_TIMESTAMP` in the way it's specified in the docs: `SELECT CURRENT_TIMESTAMP();`, it just doesn't work:
```
Invalid input error: SQL query not valid.
SQL query:
==========
select CURRENT_TIMESTAMP()
                        ^=== ERROR HERE!
==========
Error line: 0
Error column: 24
Error message: syntax error, unexpected '(', expecting end of file
```

The following syntax should be used instead: `SELECT CURRENT_TIMESTAMP;`