### PR TITLE
Update query-history-view.md

### DIFF
--- a/docs/general-reference/information-schema/query-history-view.md
+++ b/docs/general-reference/information-schema/query-history-view.md
@@ -52,7 +52,7 @@ Each row has the following columns with information about each query in query hi
 | total_ram_consumed          | BIGINT    | The total number of engine bytes in RAM consumed during query execution. |
 | returned_rows               | BIGINT    | The total number of rows returned from the query. |
 | returned_bytes              | BIGINT    | The total number of bytes returned from the query. |
-| cpu_usage_us                | BIGINT    | The query time spent on the CPU as reported by Linux kernel scheduler |
+| cpu_usage_us                | BIGINT    | The query time spent on the CPU as reported by Linux kernel scheduler - The value may be greater than overall execution time of the query because query’s execution is parallelized and CPU times across all threads and nodes is summarized. |
 | cpu_delay_us                | BIGINT    | The query time spent on the runqueue as reported by Linux kernel scheduler - The value may be greater than overall execution time of the query because query’s execution is parallelized and CPU times across all threads and nodes is summarized. |
 | time_in_queue_ms            | BIGINT    | The number of milliseconds the query spent in queue. |
 

--- a/docs/general-reference/information-schema/query-history-view.md
+++ b/docs/general-reference/information-schema/query-history-view.md
@@ -52,7 +52,7 @@ Each row has the following columns with information about each query in query hi
 | total_ram_consumed          | BIGINT    | The total number of engine bytes in RAM consumed during query execution. |
 | returned_rows               | BIGINT    | The total number of rows returned from the query. |
 | returned_bytes              | BIGINT    | The total number of bytes returned from the query. |
-| cpu_usage_us                | BIGINT    | The query time spent on the CPU as reported by Linux kernel scheduler - The value may be greater than overall execution time of the query because query’s execution is parallelized and CPU times across all threads and nodes is summarized. |
+| cpu_usage_us                | BIGINT    | The query time spent on the CPU as reported by Linux kernel scheduler. This value may be greater than overall execution time of the query, because execution is parallelized and CPU times across all threads and nodes is summarized. |
 | cpu_delay_us                | BIGINT    | The query time spent on the runqueue as reported by Linux kernel scheduler - The value may be greater than overall execution time of the query because query’s execution is parallelized and CPU times across all threads and nodes is summarized. |
 | time_in_queue_ms            | BIGINT    | The number of milliseconds the query spent in queue. |
 


### PR DESCRIPTION
Adding to the description of "cpu_usage_us" the following:  The value may be greater than overall execution time of the query because query’s execution is parallelized and CPU times across all threads and nodes is summarized.