### PR TITLE
docs: Change SQLAlchemy repo link to point at FB1.0

### DIFF
--- a/docs/developing-with-firebolt/connecting-with-sqlalchemy.md
+++ b/docs/developing-with-firebolt/connecting-with-sqlalchemy.md
@@ -16,4 +16,4 @@ The adapter is written in Python using the SQLAlchemy toolkit. It is built accor
 
 ### To get started
 
-We recommend you follow the guidelines for SQLAlchemy integration in our [Github repository](https://github.com/firebolt-db/firebolt-sqlalchemy).
+We recommend you follow the guidelines for SQLAlchemy integration in our [Github repository](https://github.com/firebolt-db/firebolt-sqlalchemy/tree/0.x).


### PR DESCRIPTION
0.x branch in sqlalchemy repo contains Firebolt 1.0 readme and code. We should point to it by default until Firebolt 2.0 is released. New changes in sqlalchemy driver for Firebolt 2.0 will be merged to the main branch.