### PR TITLE
Fix typo in rank.md

### DIFF
--- a/docs/sql-reference/functions-reference/rank.md
+++ b/docs/sql-reference/functions-reference/rank.md
@@ -15,7 +15,7 @@ For more information on usage, please refer to [Window Functions](./window-funct
 {: .no_toc}
 
 ```sql
-RANK() OVER ([PARTITION BY <exp>] ORDER BY <exp> [ASC|DESC] )
+RANK() OVER ([PARTITION BY <val>] ORDER BY <exp> [ASC|DESC] )
 ```
 
 | Parameter | Description                                                                                        |


### PR DESCRIPTION
The first `<exp>` should be `<val>` according to the parameter description below