### PR TITLE
Note that null bytes are not supported in TEXT literals

### DIFF
--- a/docs/general-reference/data-types.md
+++ b/docs/general-reference/data-types.md
@@ -40,8 +40,8 @@ Synonyms: `DOUBLE`, `FLOAT8`, `FLOAT(p)` where 25 <= p <= 53.
 ## String
 
 ### TEXT
-A string of an arbitrary length that can contain any number of bytes, including null bytes. Useful for arbitrary-length string columns. Firebolt supports UTF-8 escape sequences.
-Synonyms: `STRING`, `VARCHAR`. Note that null bytes are not supported in TEXT literals.
+A string of an arbitrary length that can contain any number of bytes. Useful for arbitrary-length string columns. Note that null bytes are not supported in TEXT literals, but are supported when importing from an external table. Firebolt supports UTF-8 escape sequences.
+Synonyms: `STRING`, `VARCHAR`
 
 ## Date and timestamp
 

--- a/docs/general-reference/data-types.md
+++ b/docs/general-reference/data-types.md
@@ -41,7 +41,7 @@ Synonyms: `DOUBLE`, `FLOAT8`, `FLOAT(p)` where 25 <= p <= 53.
 
 ### TEXT
 A string of an arbitrary length that can contain any number of bytes, including null bytes. Useful for arbitrary-length string columns. Firebolt supports UTF-8 escape sequences.
-Synonyms: `STRING`, `VARCHAR`
+Synonyms: `STRING`, `VARCHAR`. Note that null bytes are not supported in TEXT literals.
 
 ## Date and timestamp
 


### PR DESCRIPTION
This has been the case before. In 3.30 we will output an error when trying to use a null byte in a text literal.