### PR TITLE
Fix examples for regexp-extract[-all]

### DIFF
--- a/docs/sql-reference/functions-reference/regexp-extract-all.md
+++ b/docs/sql-reference/functions-reference/regexp-extract-all.md
@@ -8,7 +8,7 @@ parent: SQL functions
 # REGEXP_EXTRACT_ALL
  
 Returns an array that contains all matches of a `<pattern>` within the given `<expression>`. 
-If the pattern does not match, returns an empty array.
+If the pattern does not match, returns an empty array. If you want return the first match of `<pattern>` within the `<expression>`, use [REGEXP_EXTRACT](./regexp-extract.md).
 
 
 ```sql
@@ -17,35 +17,35 @@ REGEXP_EXTRACT_ALL(<expression>, <pattern>[,'<flag>[...]',[<index>]])
 
 | Parameter   | Description |Supported input types |
 | :----------- | :----------------------------------------- | :---------------------|
-| `<expression>`  | The string from which to extract a substring from, based on a regular expression. | `TEXT` |
+| `<expression>`  | The string from which to extract a substring, based on a regular expression. | `TEXT` |
 | `<pattern>` | A [re2 regular expression](https://github.com/google/re2/wiki/Syntax) for matching with the string. | `TEXT` | 
-| `<flag>` | Optional. Flags allow additional controls over the regular's expression matching behavior. If using multiple flags, you can include them in the same single-quote block without any separator character. | Firebolt supports the following RE2 flags to override default matching behavior. With `-` in front you can disable the flag.<br>* `i` - Specifies case-insensitive matching.<br>* `m` - Specifies multi-line mode. In this mode, `^` and `$` characters in the regex match the beginning and end of line.<br>* `s` - (Enabled per default) Specifies that the `.` metacharacter in regex matches the newline character in addition to any character in `.`<br>* `U` - Specifies non-greedy mode. In this mode, the meaning of the metacharacters `*` and `+` in regex `<pattern>` are swapped with `*?` and `+?`, respectively. See the examples using flags below for the difference in how results are returned. |
-| `<index>`| Optional. Indicates which subgroup of the expression match should be returned. Default value is `0` which means the whole match is returned, independent of any number of given subgroups. | An `INTEGER` between `0` and `N` where `N` is the number subgroups in the `<pattern>`.|
+| `<flag>` | Optional. Flag that allows additional controls over the regular's expression matching behavior. If using multiple flags, you can include them in the same single-quote block without any separator character. | Firebolt supports the following RE2 flags to override default matching behavior. With `-` in front, you can disable the flag.<br>* `i` - Specifies case-insensitive matching.<br>* `m` - Specifies multi-line mode. In this mode, `^` and `$` characters in the regex match the beginning and end of the line.<br>* `s` - (Enabled per default) Specifies that the `.` metacharacter in regex matches the newline character in addition to any character in `.`<br>* `U` - Specifies non-greedy mode. In this mode, the meaning of the metacharacters `*` and `+` in regex `<pattern>` are swapped with `*?` and `+?`, respectively. See the examples using flags below for the difference in how results are returned. |
+| `<index>`| Optional. Indicates which subgroup of each expression match should be returned. The default value is `0` which means the whole match is returned, independent of any number of given subgroups. | An `INTEGER` between `0` and `N` where `N` is the number subgroups in the `<pattern>`.|
 
 ## Return Types
-`TEXT`
+`ARRAY<TEXT>`
 
 ## Example
 {: .no_toc}
 
 ```sql
 SELECT
-	REGEXP_EXTRACT_ALL('ABC 2023', '^[A-Z]+');
+	REGEXP_EXTRACT_ALL('Hello Year 2023, yeah!', '[A-Za-z]+');
 ```
-**Returns**: `"ABC"`
+**Returns**: `["Hello", "Year", "yeah"]`
 
-Despite using subgroups in the regular expression, the full match will be returned as the optional `<index>` argument is not set (the default value `0` is used instead).
+Despite using subgroups in the regular expression, each full match will be returned as the optional `<index>` argument is not set (the default value `0` is used instead).
 
 ```sql
 SELECT
-	REGEXP_EXTRACT_ALL('Learning about #REGEX in #Firebolt 2023', '#([A-Za-z]+) (\\d+)');
+	REGEXP_EXTRACT_ALL('Learning about #REGEX in #Firebolt 2023', '#([A-Z])[a-z]+', 'i');
 ```
-**Returns**: `"Firebolt 2023"`
+**Returns**: `["#REGEX", "#Firebolt"]`
 
-The regular expression contains two subgroups which allows us to set the `<index>` argument to something between `0` and `2`. Every other value will cause an exception to be thrown. Setting `<index>` to `0` would cause the whole match `"Firebolt 2023"` to be returned (same behavior as not setting this value, see the example above), while a `2` would return the second subgroup `"2023"`.
+The regular expression contains two subgroups which allows us to set the `<index>` argument to something between `0` and `2`. Every other value will cause an exception to be thrown. Setting `<index>` to `0` would cause that all full matches `["#REGEX", "#Firebolt"]` are returned (same behavior as not setting this value, see the example above), while a `2` would return the second subgroup of each match `["EGEX", "irebolt"]`.
 
 ```sql
 SELECT
-	REGEXP_EXTRACT_ALL('Learning about #REGEX in #Firebolt 2023', '#([a-z]+) (\\d+), 'i', '1');
+	REGEXP_EXTRACT_ALL('Learning about #REGEX in #Firebolt 2023', '#([A-Z])([a-z]+)', 'i', 1);
 ```
-**Returns**: `"Firebolt"`
+**Returns**: `["R", "F"]`

--- a/docs/sql-reference/functions-reference/regexp-extract.md
+++ b/docs/sql-reference/functions-reference/regexp-extract.md
@@ -21,10 +21,10 @@ REGEXP_EXTRACT(<expression>, <pattern>[,'<flag>[...]',[<index>]])
 
 | Parameter   | Description |Supported input types |
 | :----------- | :----------------------------------------- | :---------------------|
-| `<expression>`  | The string from which to extract a substring from, based on a regular expression. | `TEXT` |
+| `<expression>`  | The string from which to extract a substring, based on a regular expression. | `TEXT` |
 | `<pattern` | A [re2 regular expression](https://github.com/google/re2/wiki/Syntax) for matching with the string. | `TEXT` | 
-| `<flag>` | Optional. Flag that allow additional controls over the regular's expression matching behavior. If using multiple flags, you can include them in the same single-quote block without any separator character. | Firebolt supports the following RE2 flags to override default matching behavior. With `-` in front you can disable the flag.<br>* `i` - Specifies case-insensitive matching.<br>* `m` - Specifies multi-line mode. In this mode, `^` and `$` characters in the regex match the beginning and end of line.<br>* `s` - (Enabled per default) Specifies that the `.` metacharacter in regex matches the newline character in addition to any character in `.`<br>* `U` - Specifies non-greedy mode. In this mode, the meaning of the metacharacters `*` and `+` in regex `<pattern>` are swapped with `*?` and `+?`, respectively. See the examples using flags below for the difference in how results are returned. |
-| `<index>`| Optional. Indicates which subgroup of the expression match should be returned. Default value is `0` which means the whole match is returned, independent of any number of given subgroups. | An `INTEGER` between `0` and `N` where `N` is the number subgroups in the `<pattern>`.|
+| `<flag>` | Optional. Flag that allows additional controls over the regular's expression matching behavior. If using multiple flags, you can include them in the same single-quote block without any separator character. | Firebolt supports the following RE2 flags to override default matching behavior. With `-` in front, you can disable the flag.<br>* `i` - Specifies case-insensitive matching.<br>* `m` - Specifies multi-line mode. In this mode, `^` and `$` characters in the regex match the beginning and end of the line.<br>* `s` - (Enabled per default) Specifies that the `.` metacharacter in regex matches the newline character in addition to any character in `.`<br>* `U` - Specifies non-greedy mode. In this mode, the meaning of the metacharacters `*` and `+` in regex `<pattern>` are swapped with `*?` and `+?`, respectively. See the examples using flags below for the difference in how results are returned. |
+| `<index>`| Optional. Indicates which subgroup of the expression match should be returned. The default value is `0` which means the whole match is returned, independent of any number of given subgroups. | An `INTEGER` between `0` and `N` where `N` is the number subgroups in the `<pattern>`.|
 
 ## Return Types
 `TEXT`
@@ -34,23 +34,23 @@ REGEXP_EXTRACT(<expression>, <pattern>[,'<flag>[...]',[<index>]])
 
 ```sql
 SELECT
-	REGEXP_EXTRACT('Hello Year 2023 DEF', '[A-Za-z]+');
+	REGEXP_EXTRACT('ABC 2023', '^[A-Z]+');
 ```
-**Returns**: `["Hello", "Year"]`
+**Returns**: `"ABC"`
 
-Despite using subgroups in the regular expression, the each full match will be returned as the optional `<index>` argument is not set (the default value `0` is used instead).
+Despite using subgroups in the regular expression, the full match will be returned as the optional `<index>` argument is not set (the default value `0` is used instead).
 
 ```sql
 SELECT
-	REGEXP_EXTRACT('Learning about #REGEX in #Firebolt 2023', '#([A-Z])[a-z]+');
+	REGEXP_EXTRACT('Learning about #REGEX in #Firebolt 2023', '#([A-Za-z]+) (\\d+)');
 ```
-**Returns**: `["Learning", "Firebolt"]`
+**Returns**: `"#Firebolt 2023"`
 
-The regular expression contains two subgroups which allows us to set the `<index>` argument to something between `0` and `2`. Every other value will cause an exception to be thrown. Setting `<index>` to `0` would cause the all full matches `["Learning", "Firebolt"]` to be returned (same behavior as not setting this value, see the example above), while a `2` would return the second subgroup of each match `["earning", "irebolt"]`.
+The regular expression contains two subgroups which allows us to set the `<index>` argument to something between `0` and `2`. Every other value will cause an exception to be thrown. Setting `<index>` to `0` would cause the full match `"#Firebolt 2023"` to be returned (same behavior as not setting this value, see the example above), while a `2` would return the second subgroup `"2023"`.
 
 ```sql
 SELECT
-	REGEXP_EXTRACT('Learning about #REGEX in #Firebolt 2023', '#([A-Z])[a-z]+', '', '1');
+	REGEXP_EXTRACT('Learning about #REGEX in #Firebolt 2023', '#([a-z]+) (\\d+)', 'i', 1);
 ```
-**Returns**: `["L", "F"]`
+**Returns**: `"Firebolt"`
 


### PR DESCRIPTION
The examples for `regex-extract` and `regex-extract-all` were switched.
Also, fix some typos.