### PR TITLE
FIR-28289 Change SUBSTRING's <start> and <count> parameters to BIGINT

### DIFF
--- a/docs/sql-reference/functions-reference/substring.md
+++ b/docs/sql-reference/functions-reference/substring.md
@@ -21,8 +21,8 @@ SUBSTRING(<expression> [FROM <start>] [FOR <count>])
 | Parameter | Description                         |Supported input types |
 | :--------- | :----------------------------------- | :---------------------|
 | `<expression>`  | The input string.   	| `TEXT` |
-| `<start>`   | Optional. The starting position for the substring. 1 is the first character. | `INTEGER` |
-| `<count>`   | Optional. The number of characters to be returned by the `SUBSTRING` function. Must be positive or 0. If not specified, `count` by default returns all of the string not specified by the `start` parameter. | `INTEGER` |
+| `<start>`   | Optional. The starting position for the substring. 1 is the first character. | `BIGINT` |
+| `<count>`   | Optional. The number of characters to be returned by the `SUBSTRING` function. Must be positive or 0. If not specified, `count` by default returns all of the string not specified by the `start` parameter. | `BIGINT` |
 
 At least one of the optional arguments `<start>` and `<count>` must be given.
 


### PR DESCRIPTION
PackDB PR: https://github.com/firebolt-analytics/packdb/pull/8531 .

We used to define the signature of `substring` function following PostgreSQL, which has `<start>` and `<count>` parameters defined as `INTEGER`. Calling `substring` with `BIGINT` values for these parameters fail in PostgreSQL, and we kept the same behavior.

However, we agreed that this is not very convenient. Supporting `BIGINT` types for these parameters should be a natural extension. It does not hurt our "PostgreSQL compliant" claim. In addition, given that we still produce `BIGINT` for arithmetic addition of integers, this is just convenient for our user to make in-position call to other functions.