### PR TITLE
Clarify no official Python 3.7 support in cli

### DIFF
--- a/docs/using-the-cli.md
+++ b/docs/using-the-cli.md
@@ -17,7 +17,7 @@ This topic covers installation, configuration, and running queries. For a list o
 
 ## Prerequisites
 
-* The CLI requires Python version 3.7 or later along with the pip package installer. For more information, see the [Python](https://www.python.org/downloads/) web page.
+* The CLI requires Python version 3.8 or later along with the pip package installer. For more information, see the [Python](https://www.python.org/downloads/) web page.
 
 * You need a Firebolt account and login credentials.
 


### PR DESCRIPTION
3.7 has been deprecated for a while now with no security updates. We have 3.8+ support in the repo readme and now reflecting this in our docs.