### PR TITLE
Update connecting-with-net.md

### DIFF
--- a/docs/developing-with-firebolt/connecting-with-net.md
+++ b/docs/developing-with-firebolt/connecting-with-net.md
@@ -8,4 +8,4 @@ parent: Developing with Firebolt
 
 # .NET
 
-Firebolt provides a .NET Core driver (.NET 6) for developing .NET applications on Firebolt. For installation and usage instructions, see the [firebolt-net-sdk](https://github.com/firebolt-db/firebolt-net-sdk) repository on GitHub.
+Firebolt provides a .NET Core driver (.NET 6) for developing .NET applications on Firebolt. For installation and usage instructions, see the [firebolt-net-sdk](https://github.com/firebolt-db/firebolt-net-sdk/tree/0.x) repository on GitHub.


### PR DESCRIPTION
The existing URL is referring to FB2.0 repository. Updated the link to the FB1.0 repository.  Discussed here: https://firebolt-analytics.slack.com/archives/C01N37CCMHV/p1715612715929829?thread_ts=1715606595.292359&cid=C01N37CCMHV